### PR TITLE
added maven pom

### DIFF
--- a/AceGWT/pom.xml
+++ b/AceGWT/pom.xml
@@ -1,0 +1,99 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>edu.ycp.cs.dh</groupId>
+  <artifactId>AceGWT</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <properties>
+    <!-- Convenience property to set the GWT version -->
+    <gwt.version>2.8.0-beta1</gwt.version>
+
+    <!-- GWT needs at least java 1.7 -->
+    <maven.compiler.source>1.7</maven.compiler.source>
+    <maven.compiler.target>1.7</maven.compiler.target>
+
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
+    <gwt-maven-plugin.version>2.8.0-beta1</gwt-maven-plugin.version>
+    <junit.version>4.11</junit.version>
+  </properties>
+
+  <build>
+    <sourceDirectory>./src</sourceDirectory>
+    <resources>
+      <resource>
+        <directory>./src</directory>
+
+      </resource>
+    </resources>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>${maven-compiler-plugin.version}</version>
+        <configuration>
+          <source />
+          <target />
+        </configuration>
+      </plugin>
+      <!-- Mojo's Maven Plugin for GWT (not used here, since there is no 
+        entrypoint) -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>gwt-maven-plugin</artifactId>
+        <version>${gwt-maven-plugin.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>compile</goal>
+              <goal>test</goal>
+              <goal>generateAsync</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <runTarget>acegwt.html</runTarget>
+          <modules>
+            <module>edu.ycp.cs.dh.acegwt.AceGWT</module>
+          </modules>
+        </configuration>
+      </plugin>
+
+    </plugins>
+  </build>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>com.google.gwt</groupId>
+        <artifactId>gwt</artifactId>
+        <version>${gwt.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-servlet</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-user</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.gwt</groupId>
+      <artifactId>gwt-dev</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>


### PR DESCRIPTION
Mit der pom kann man AceGWT als dependecy in maven eintragen und verwenden.
Gwt springt erst an wenn es einen entrypoint gibt. Um AceGWT dann mit gwt zu kompilieren muss in dem Projekt, dass das UI macht AceGWT mit inherit im gwt-modul eingetragen werden.
